### PR TITLE
Hide old status icons on Firefox as well

### DIFF
--- a/master.css
+++ b/master.css
@@ -483,3 +483,8 @@ img[src*="progress-unknown.gif"], img[src*="progress-unknown-red.gif"] {
     height: 48px;
     padding: 0 48px 0 0;
 }
+
+img.build-status-icon {
+    width: 0;
+    padding: 0 16px 0 0;
+}


### PR DESCRIPTION
This pull request fixes issue #5.

Tested on Chrome 33.0.1750.117 beta and Firefox 28.0 beta.
