### PR TITLE
Replace every status icon by the compatible way with Firefox

### DIFF
--- a/master.css
+++ b/master.css
@@ -418,14 +418,17 @@ Keyframes inprogress {
     }
 }
 
-img[src*="blue.png"], img[src*="yellow.png"], img[src*="red.png"], img[src*="grey.png"],
-img[src*="disabled.png"], img[src*="nobuilt.png"], img[src*="aborted.png"], img[src*="blue_anime.gif"], 
-img[src*="yellow_anime.gif"], img[src*="red_anime.gif"], img[src*="grey_anime.gif"],
-img[src*="disabled_anime.gif"], img[src*="nobuilt_anime.gif"], img[src*="aborted_anime.gif"] {
+img[src$="blue.png"],     img[src$="blue.gif"],     img[src$="blue_anime.gif"],
+img[src$="yellow.png"],   img[src$="yellow.gif"],   img[src$="yellow_anime.gif"],
+img[src$="red.png"],      img[src$="red.gif"],      img[src$="red_anime.gif"],
+img[src$="grey.png"],     img[src$="grey.gif"],     img[src$="grey_anime.gif"],
+img[src$="disabled.png"], img[src$="disabled.gif"], img[src$="disabled_anime.gif"],
+img[src$="nobuilt.png"],  img[src$="nobuilt.gif"],  img[src$="nobuilt_anime.gif"],
+img[src$="aborted.png"],  img[src$="aborted.gif"],  img[src$="aborted_anime.gif"] {
     content: url('data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==');
     -webkit-border-radius: 50%;
     -moz-border-radius: 50%;
-    padding: 1px;
+    padding: 0;
     border-radius: 50%;
     background: #BBB !important;
 }
@@ -460,22 +463,50 @@ img[src*="progress-unknown.gif"], img[src*="progress-unknown-red.gif"] {
     padding: 0px;
 }
 
-.icon16x16:not(.build-health-icon) {
-    width: 14px;
-    height: 14px;
+img[src$="images/16x16/blue.png"],     img[src$="images/16x16/blue.gif"],     img[src$="images/16x16/blue_anime.gif"],
+img[src$="images/16x16/yellow.png"],   img[src$="images/16x16/yellow.gif"],   img[src$="images/16x16/yellow_anime.gif"],
+img[src$="images/16x16/red.png"],      img[src$="images/16x16/red.gif"],      img[src$="images/16x16/red_anime.gif"],
+img[src$="images/16x16/grey.png"],     img[src$="images/16x16/grey.gif"],     img[src$="images/16x16/grey_anime.gif"],
+img[src$="images/16x16/disabled.png"], img[src$="images/16x16/disabled.gif"], img[src$="images/16x16/disabled_anime.gif"],
+img[src$="images/16x16/nobuilt.png"],  img[src$="images/16x16/nobuilt.gif"],  img[src$="images/16x16/nobuilt_anime.gif"],
+img[src$="images/16x16/aborted.png"],  img[src$="images/16x16/aborted.gif"],  img[src$="images/16x16/aborted_anime.gif"] {
+    width: 0;
+    height: 16px;
+    padding: 0 16px 0 0;
 }
 
-.icon24x24:not(.build-health-icon) {
-    width: 22px;
-    height: 22px;
+img[src$="images/24x24/blue.png"],     img[src$="images/24x24/blue.gif"],     img[src$="images/24x24/blue_anime.gif"],
+img[src$="images/24x24/yellow.png"],   img[src$="images/24x24/yellow.gif"],   img[src$="images/24x24/yellow_anime.gif"],
+img[src$="images/24x24/red.png"],      img[src$="images/24x24/red.gif"],      img[src$="images/24x24/red_anime.gif"],
+img[src$="images/24x24/grey.png"],     img[src$="images/24x24/grey.gif"],     img[src$="images/24x24/grey_anime.gif"],
+img[src$="images/24x24/disabled.png"], img[src$="images/24x24/disabled.gif"], img[src$="images/24x24/disabled_anime.gif"],
+img[src$="images/24x24/nobuilt.png"],  img[src$="images/24x24/nobuilt.gif"],  img[src$="images/24x24/nobuilt_anime.gif"],
+img[src$="images/24x24/aborted.png"],  img[src$="images/24x24/aborted.gif"],  img[src$="images/24x24/aborted_anime.gif"] {
+    width: 0;
+    height: 24px;
+    padding: 0 24px 0 0;
 }
 
-.icon32x32:not(.build-health-icon) {
-    width: 30px;
-    height: 30px;
+img[src$="images/32x32/blue.png"],     img[src$="images/32x32/blue.gif"],     img[src$="images/32x32/blue_anime.gif"],
+img[src$="images/32x32/yellow.png"],   img[src$="images/32x32/yellow.gif"],   img[src$="images/32x32/yellow_anime.gif"],
+img[src$="images/32x32/red.png"],      img[src$="images/32x32/red.gif"],      img[src$="images/32x32/red_anime.gif"],
+img[src$="images/32x32/grey.png"],     img[src$="images/32x32/grey.gif"],     img[src$="images/32x32/grey_anime.gif"],
+img[src$="images/32x32/disabled.png"], img[src$="images/32x32/disabled.gif"], img[src$="images/32x32/disabled_anime.gif"],
+img[src$="images/32x32/nobuilt.png"],  img[src$="images/32x32/nobuilt.gif"],  img[src$="images/32x32/nobuilt_anime.gif"],
+img[src$="images/32x32/aborted.png"],  img[src$="images/32x32/aborted.gif"],  img[src$="images/32x32/aborted_anime.gif"] {
+    width: 0;
+    height: 32px;
+    padding: 0 32px 0 0;
 }
 
-.icon48x48:not(.build-health-icon) {
-    width: 46px;
-    height: 46px;
+img[src$="images/48x48/blue.png"],     img[src$="images/48x48/blue.gif"],     img[src$="images/48x48/blue_anime.gif"],
+img[src$="images/48x48/yellow.png"],   img[src$="images/48x48/yellow.gif"],   img[src$="images/48x48/yellow_anime.gif"],
+img[src$="images/48x48/red.png"],      img[src$="images/48x48/red.gif"],      img[src$="images/48x48/red_anime.gif"],
+img[src$="images/48x48/grey.png"],     img[src$="images/48x48/grey.gif"],     img[src$="images/48x48/grey_anime.gif"],
+img[src$="images/48x48/disabled.png"], img[src$="images/48x48/disabled.gif"], img[src$="images/48x48/disabled_anime.gif"],
+img[src$="images/48x48/nobuilt.png"],  img[src$="images/48x48/nobuilt.gif"],  img[src$="images/48x48/nobuilt_anime.gif"],
+img[src$="images/48x48/aborted.png"],  img[src$="images/48x48/aborted.gif"],  img[src$="images/48x48/aborted_anime.gif"] {
+    width: 0;
+    height: 48px;
+    padding: 0 48px 0 0;
 }


### PR DESCRIPTION
This pull request fixes issue #5. Replacement of #6.

Tested on Chrome 33.0.1750.117 beta and Firefox 28.0 beta.

Note: http://stackoverflow.com/a/13552989/676818
This script was used to generate repetitive CSS selectors: http://ideone.com/jgoUCV
