### PR TITLE
Fix Upstream/Downstream Projects formatting

### DIFF
--- a/master.css
+++ b/master.css
@@ -2,6 +2,11 @@ body {
     background: #fff!important;
 }
 
+#main-panel > ul:nth-child(8) > li > img {
+    margin-right: 10px;
+    margin-bottom: 10px;
+}
+
 #top-panel {
     height: 55px!important;
     padding-top: 15px;


### PR DESCRIPTION
This fixes the formatting for the builds listed under "upstream projects" and "downstream projects". The circles were too close to the job name, and the list was too clumped together.
