### PR TITLE
Fix size of L icon cause 24px is M size

### DIFF
--- a/master.css
+++ b/master.css
@@ -792,9 +792,9 @@ img[src$="images/32x32/disabled.png"], img[src$="images/32x32/disabled.gif"], im
 img[src$="images/32x32/nobuilt.png"],  img[src$="images/32x32/nobuilt.gif"],  img[src$="images/32x32/nobuilt_anime.gif"],
 img[src$="images/32x32/aborted.png"],  img[src$="images/32x32/aborted.gif"],  img[src$="images/32x32/aborted_anime.gif"] {
     width: 0;
-    height: 24px;
-    padding: 0 24px 0 0;
-	margin-left: 5px;
+    height: 32px;
+    padding: 0 32px 0 0;
+    margin-left: 5px;
 }
 
 img[src$="images/48x48/blue.png"],     img[src$="images/48x48/blue.gif"],     img[src$="images/48x48/blue_anime.gif"],


### PR DESCRIPTION
Jenkins default size of L icon is 32px on inline css.

Hope to match :point_up: 